### PR TITLE
Updated archlinux docker image

### DIFF
--- a/dex-images/tetris/Dockerfile
+++ b/dex-images/tetris/Dockerfile
@@ -1,4 +1,4 @@
-FROM base/archlinux
+FROM archlinux/base
 
 ENV DEXBUILD_DIR="/bin"
 


### PR DESCRIPTION
I change the archlinux image you're using because it is not the official and it's deprecated (https://hub.docker.com/r/base/archlinux/).