### PR TITLE
Update Game.hs

### DIFF
--- a/src/UI/Game.hs
+++ b/src/UI/Game.hs
@@ -66,7 +66,8 @@ playGame lvl mp = do
     writeBChan chan Tick
     threadDelay delay
   initialGame <- initGame lvl
-  ui <- customMain (V.mkVty V.defaultConfig) (Just chan) app $ UI
+  initialVty <-V.mkVty =<< V.standardIOConfig
+  ui <- customMain initialVty (V.mkVty V.defaultConfig) (Just chan) app $ UI
     { _game    = initialGame
     , _preview = mp
     , _locked  = False


### PR DESCRIPTION
0.47
API changes:
Changed Brick.Main.customMain so that it now takes an additional (first) argument: the initial Vty handle to use. This lets the caller have more control over the terminal state when, for example, they have previously set up Vty to do other work before calling customMain.

via brick/CHANGELOG.md