### PR TITLE
Added functionality to choose whether a user wants level progression or not, and reflect that in the game window.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -71,10 +71,10 @@ hdOptStr (CustomChars s) = Just s
 main :: IO ()
 main = do
   (Opts hd ml hs) <- execParser fullopts
-  when hs (getHighScore >>= printM >> exitSuccess)
-  levelConfig <- maybe pickLevel (\l -> return $ LevelConfig l False) ml
-  g <- playGame (levelNumber levelConfig) (hdOptStr hd) (progression levelConfig)
-  handleEndGame (_score g)
+  when hs (getHighScore >>= printM >> exitSuccess)                                  -- show high score and exit
+  levelConfig <- maybe pickLevel (\l -> return $ LevelConfig l False) ml            -- pick level prompt if necessary
+  g <- playGame (levelNumber levelConfig) (hdOptStr hd) (progression levelConfig)   -- play game
+  handleEndGame (_score g)                                                          -- save & print score
 
 handleEndGame :: Int -> IO ()
 handleEndGame s = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,7 @@ import qualified System.Directory as D
 import System.FilePath ((</>))
 
 import Tetris (Game(..))
-import UI.PickLevel (pickLevel)
+import UI.PickLevel (pickLevel, LevelConfig(..))
 import UI.Game (playGame)
 
 data Opts = Opts
@@ -70,11 +70,11 @@ hdOptStr (CustomChars s) = Just s
 
 main :: IO ()
 main = do
-  (Opts hd ml hs) <- execParser fullopts           -- get CLI opts/args
-  when hs (getHighScore >>= printM >> exitSuccess) -- show high score and exit
-  l <- maybe pickLevel return ml                   -- pick level prompt if necessary
-  g <- playGame l (hdOptStr hd)                    -- play game
-  handleEndGame (_score g)                         -- save & print score
+  (Opts hd ml hs) <- execParser fullopts
+  when hs (getHighScore >>= printM >> exitSuccess)
+  levelConfig <- maybe pickLevel (\l -> return $ LevelConfig l False) ml
+  g <- playGame (levelNumber levelConfig) (hdOptStr hd) (progression levelConfig)
+  handleEndGame (_score g)
 
 handleEndGame :: Int -> IO ()
 handleEndGame s = do

--- a/src/Tetris.hs
+++ b/src/Tetris.hs
@@ -162,7 +162,7 @@ bagFourTetriminoEach Empty =
   bagFourTetriminoEach <=< shuffle . Seq.fromList . take 28 $ cycle [I ..]
 
 -- | Initialize a game with a given level
-initGame :: Int -> Bool -> IO Game  -- Updated signature
+initGame :: Int -> Bool -> IO Game 
 initGame lvl prog = do
   (s1, bag1) <- bagFourTetriminoEach mempty
   (s2, bag2) <- bagFourTetriminoEach bag1
@@ -174,7 +174,7 @@ initGame lvl prog = do
     , _score        = 0
     , _linesCleared = 0
     , _board        = mempty
-    , _progression  = prog  -- Added prog parameter
+    , _progression  = prog  
     }
 
 -- | Increment level

--- a/src/Tetris.hs
+++ b/src/Tetris.hs
@@ -25,7 +25,7 @@ module Tetris
   , Tetrimino(..)
   , Tetris
   -- Lenses
-  , block, board, level, nextShape, score, shape, linesCleared
+  , block, board, level, nextShape, score, shape, linesCleared, progression
   -- Constants
   , boardHeight, boardWidth, relCells
   ) where
@@ -82,6 +82,7 @@ data Game = Game
   , _linesCleared :: Int
   , _score        :: Int
   , _board        :: Board
+  , _progression  :: Bool
   } deriving (Eq)
 makeLenses ''Game
 
@@ -161,8 +162,8 @@ bagFourTetriminoEach Empty =
   bagFourTetriminoEach <=< shuffle . Seq.fromList . take 28 $ cycle [I ..]
 
 -- | Initialize a game with a given level
-initGame :: Int -> IO Game
-initGame lvl = do
+initGame :: Int -> Bool -> IO Game  -- Updated signature
+initGame lvl prog = do
   (s1, bag1) <- bagFourTetriminoEach mempty
   (s2, bag2) <- bagFourTetriminoEach bag1
   pure $ Game
@@ -173,6 +174,7 @@ initGame lvl = do
     , _score        = 0
     , _linesCleared = 0
     , _board        = mempty
+    , _progression  = prog  -- Added prog parameter
     }
 
 -- | Increment level
@@ -191,9 +193,12 @@ timeStep = do
     True -> do
       freezeBlock
       clearFullRows >>= updateScore
-      levelFinished >>= \case
-        True -> nextLevel
-        False -> nextBlock
+      prog <- use progression
+      when prog $ do
+        levelFinished >>= \case
+          True -> nextLevel
+          False -> pure ()
+      nextBlock
 
 -- | Gravitate current block, i.e. shift down
 gravitate :: MonadState Game m => m ()
@@ -235,9 +240,13 @@ updateScore lines = do
 -- | Using the fixed-goal system described here: https://tetris.wiki/Marathon
 levelFinished :: (MonadState Game m, MonadIO m) => m Bool
 levelFinished = do
-  lvl <- use level
-  lc <- use linesCleared
-  pure $ lvl < 15 && lc >= 10 * (lvl + 1)
+  prog <- use progression
+  if not prog
+    then pure False
+    else do
+      lvl <- use level
+      lc <- use linesCleared
+      pure $ lvl < 15 && lc >= 10 * (lvl + 1)
 
 -- | Handle counterclockwise block rotation (if possible)
 -- Allows wallkicks: http://tetris.wikia.com/wiki/TGM_rotation

--- a/src/UI/Game.hs
+++ b/src/UI/Game.hs
@@ -220,10 +220,10 @@ drawStats g =
 -- | Displays current progression mode setting (ON: automatic level ups, OFF: fixed level)
 drawProgression :: Bool -> Widget Name
 drawProgression True =
-    padLeftRight 1 $ str "Level Mode: " <+>
+    padLeftRight 1 $ str "Level Mode" <+>
     withAttr progressionAttr (padLeft Max $ str "ON")
 drawProgression False =
-    padLeftRight 1 $ str "Level Mode: " <+>
+    padLeftRight 1 $ str "Level Mode" <+>
     withAttr fixedAttr (padLeft Max $ str "Fixed")
 
 drawStat :: String -> Int -> Widget Name

--- a/src/UI/Game.hs
+++ b/src/UI/Game.hs
@@ -1,344 +1,121 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TupleSections #-}
-module UI.Game
-  ( playGame
+module UI.PickLevel
+  ( pickLevel
+  , LevelConfig(..)
   ) where
 
-import Control.Concurrent (threadDelay, forkIO)
-import Control.Concurrent.STM (TVar, newTVarIO, readTVarIO, writeTVar, atomically)
-import Control.Monad (void, forever)
-import Prelude hiding (Left, Right)
+import System.Exit (exitSuccess)
+import Control.Monad (when)
 
-import Brick hiding (Down)
-import Brick.BChan
+import Brick
 import qualified Brick.Widgets.Border as B
 import qualified Brick.Widgets.Border.Style as BS
 import qualified Brick.Widgets.Center as C
-import Control.Lens hiding (preview, op, zoom)
-import Control.Monad.Extra (orM, unlessM)
-import Control.Monad.IO.Class (liftIO)
 import qualified Graphics.Vty as V
-import qualified Graphics.Vty.CrossPlatform
-import qualified Graphics.Vty.Config
-import Data.Map (Map)
-import qualified Data.Map as M
-import Linear.V2 (V2(..))
 
-import Tetris
+data LevelConfig = LevelConfig
+  { levelNumber :: Int
+  , progression :: Bool
+  } deriving (Show, Eq)
 
-data UI = UI
-  { _game      :: Game         -- ^ tetris game
-  , _initLevel :: Int          -- ^ initial level chosen
-  , _currLevel :: TVar Int     -- ^ current level
-  , _preview   :: Maybe String -- ^ hard drop preview cell
-  , _locked    :: Bool         -- ^ lock after hard drop before time step
-  , _paused    :: Bool         -- ^ game paused
+data MenuOption = YesOption | NoOption deriving (Eq)
+
+data PickState = PickState
+  { currentLevel :: Maybe Int
+  , showProgression :: Bool
+  , pickingLevel :: Bool
+  , selectedOption :: MenuOption
   }
 
-makeLenses ''UI
-
--- | Ticks mark passing of time
-data Tick = Tick
-
--- | Named resources
-type Name = ()
-
-data VisualBlock
-  = NormalBlock
-  | HardDropBlock String
-
--- App definition and execution
-
-app :: App UI Tick Name
+app :: App PickState e ()
 app = App
   { appDraw         = drawUI
-  , appChooseCursor = neverShowCursor
   , appHandleEvent  = handleEvent
   , appStartEvent   = pure ()
-  , appAttrMap      = const theMap
+  , appAttrMap      = const $ attrMap V.defAttr
+      [ (selectedAttr, V.black `on` V.white)
+      ]
+  , appChooseCursor = neverShowCursor
   }
 
-playGame :: Int -> Maybe String -> Bool -> IO Game
-playGame lvl mp prog = do
-  chan <- newBChan 10
-  tv <- newTVarIO lvl
-  void . forkIO $ forever $ do
-    writeBChan chan Tick
-    lvl <- readTVarIO tv
-    threadDelay $ levelToDelay lvl
-  initialGame <- initGame lvl prog  -- Initialize game with progression mode flag
-  let buildVty = Graphics.Vty.CrossPlatform.mkVty Graphics.Vty.Config.defaultConfig
-  initialVty <- buildVty
-  ui <- customMain initialVty buildVty (Just chan) app $ UI
-    { _game      = initialGame
-    , _initLevel = lvl
-    , _currLevel = tv
-    , _preview   = mp
-    , _locked    = False
-    , _paused    = False
-    }
-  return $ ui ^. game
+selectedAttr :: AttrName
+selectedAttr = attrName "selected"
 
--- | Convert level to delay in microseconds. Higher levels = faster speed.
--- In progression mode this automatically increases difficulty.
-levelToDelay :: Int -> Int
-levelToDelay n = floor $ 400000 * (0.85 :: Double) ^ (2 * n)
+drawUI :: PickState -> [Widget ()]
+drawUI ps = [ui ps]
 
--- Handling events
-
-handleEvent :: BrickEvent Name Tick -> EventM Name UI ()
-handleEvent (VtyEvent (V.EvKey (V.KChar 'r') [])) = restart
-handleEvent (VtyEvent (V.EvKey (V.KChar 'q') [])) = halt
-handleEvent (VtyEvent (V.EvKey V.KEsc        [])) = halt
-handleEvent (VtyEvent (V.EvKey V.KRight      [])) = exec (shift Right)
-handleEvent (VtyEvent (V.EvKey V.KLeft       [])) = exec (shift Left)
-handleEvent (VtyEvent (V.EvKey V.KDown       [])) = exec (shift Down)
-handleEvent (VtyEvent (V.EvKey (V.KChar 'l') [])) = exec (shift Right)
-handleEvent (VtyEvent (V.EvKey (V.KChar 'h') [])) = exec (shift Left)
-handleEvent (VtyEvent (V.EvKey (V.KChar 'j') [])) = exec (shift Down)
-handleEvent (VtyEvent (V.EvKey V.KUp         [])) = exec rotate
-handleEvent (VtyEvent (V.EvKey (V.KChar 'k') [])) = exec rotate
-handleEvent (VtyEvent (V.EvKey (V.KChar ' ') [])) =
-  unlessM (orM [use paused, use (game . to isGameOver)]) $ do
-    zoom game hardDrop
-    assign locked True
-handleEvent (VtyEvent (V.EvKey (V.KChar 'p') [])) =
-  unlessM (orM [use locked, use (game . to isGameOver)]) $ do
-    modifying paused not
-handleEvent (AppEvent Tick                      ) =
-  unlessM (orM [use paused, use (game . to isGameOver)]) $ do
-    zoom game timeStep
-    -- Keep level in sync with ticker (gross)
-    lvl <- use $ game . level
-    tv <- use $ currLevel
-    liftIO . atomically $ writeTVar tv lvl
-    assign locked False
-handleEvent _ = pure ()
-
--- | This common execution function is used for all game user input except hard
--- drop and pause. If paused or locked (from hard drop) do nothing, else
--- execute the state computation.
-exec :: Tetris () -> EventM Name UI ()
-exec = unlessM (orM [use paused, use locked, use (game . to isGameOver)]) . zoom game
-
--- | Restart game at the initially chosen level, maintaining progression setting
-restart :: EventM Name UI ()
-restart = do
-  lvl <- use initLevel
-  prog <- use (game . progression)  -- Get current progression setting
-  g <- liftIO $ initGame lvl prog   -- Use it when restarting
-  assign game g
-  assign locked False
-
--- Drawing
-
-drawUI :: UI -> [Widget Name]
-drawUI ui =
-  [ C.vCenter $ vLimit 22 $ hBox
-      [ padLeft Max $ padRight (Pad 2) $ drawStats (ui ^. game)
-      , drawGrid ui
-      , padRight Max $ padLeft (Pad 2) $ drawInfo (ui ^. game)
-      ]
-  ]
-
-drawGrid :: UI -> Widget Name
-drawGrid ui =
-  hLimit 22
+ui :: PickState -> Widget ()
+ui ps =
+  padLeft (Pad 19)
+    $ padRight (Pad 21)
+    $ C.center
+    $ vLimit 22
+    $ hLimit 22
     $ withBorderStyle BS.unicodeBold
     $ B.borderWithLabel (str "Tetris")
-    $ case ui ^. paused of
-        True  -> C.center $ str "Paused"
-        False -> vBox $ [boardHeight, boardHeight - 1 .. 1] <&> \r ->
-          foldr (<+>) emptyWidget
-            . M.filterWithKey (\(V2 _ y) _ -> r == y)
-            $ mconcat
-                [ drawBlockCell NormalBlock <$> ui ^. (game . board)
-                , blockMap NormalBlock (ui ^. (game . block))
-                , case ui ^. preview of
-                    Nothing -> M.empty
-                    Just s  -> blockMap (HardDropBlock s) (evalTetris hardDroppedBlock (ui ^. game))
-                , emptyCellMap
-                ]
- where
-  blockMap v b =
-    M.fromList $ [ (c, drawBlockCell v (b ^. shape)) | c <- coords b ]
-
-emptyCellMap :: Map Coord (Widget Name)
-emptyCellMap = M.fromList
-  [ (V2 x y, emptyGridCellW) | x <- [1 .. boardWidth], y <- [1 .. boardHeight] ]
-
-emptyGridCellW :: Widget Name
-emptyGridCellW = withAttr emptyAttr cw
-
-emptyNextShapeCellW :: Widget Name
-emptyNextShapeCellW = withAttr emptyAttr ecw
-
-drawBlockCell :: VisualBlock -> Tetrimino -> Widget Name
-drawBlockCell NormalBlock       t = withAttr (tToAttr t) cw
-drawBlockCell (HardDropBlock s) t = withAttr (tToAttrH t) (str s)
-
-tToAttr :: Tetrimino -> AttrName
-tToAttr I = iAttr
-tToAttr O = oAttr
-tToAttr T = tAttr
-tToAttr S = sAttr
-tToAttr Z = zAttr
-tToAttr J = jAttr
-tToAttr L = lAttr
-
-tToAttrH :: Tetrimino -> AttrName
-tToAttrH I = ihAttr
-tToAttrH O = ohAttr
-tToAttrH T = thAttr
-tToAttrH S = shAttr
-tToAttrH Z = zhAttr
-tToAttrH J = jhAttr
-tToAttrH L = lhAttr
-
-cw :: Widget Name
-cw = str " ."
-
-ecw :: Widget Name
-ecw = str "  "
-
-drawStats :: Game -> Widget Name
-drawStats g =
-  hLimit 22
-    $ withBorderStyle BS.unicodeBold
-    $ B.borderWithLabel (str "Stats")
+    $ C.center
     $ vBox
-        [ drawStat "Score" $ g ^. score
-        , padTop (Pad 1) $ drawStat "Lines" $ g ^. linesCleared
-        , padTop (Pad 1) $ drawStat "Level" $ g ^. level
-        , padTop (Pad 1) $ drawProgression (g ^. progression) -- Show if level progression is enabled
-        , drawLeaderBoard g
-        ]
-
--- | Displays current progression mode setting (ON: automatic level ups, OFF: fixed level)
-drawProgression :: Bool -> Widget Name
-drawProgression True =
-    padLeftRight 1 $ str "Level Mode" <+>
-    withAttr progressionAttr (padLeft Max $ str "ON")
-drawProgression False =
-    padLeftRight 1 $ str "Level Mode" <+>
-    withAttr fixedAttr (padLeft Max $ str "Fixed")
-
-drawStat :: String -> Int -> Widget Name
-drawStat s n = padLeftRight 1 $ str s <+> padLeft Max (str $ show n)
-
-drawLeaderBoard :: Game -> Widget Name
-drawLeaderBoard _ = emptyWidget
-
-drawInfo :: Game -> Widget Name
-drawInfo g = hLimit 18 -- size of next piece box
-  $ vBox
-    [ drawNextShape (g ^. nextShape)
-    , padTop (Pad 1) drawHelp
-    , padTop (Pad 1) (drawGameOver g)
+    [ if pickingLevel ps
+        then str "Choose Level (0-9)"
+        else vBox
+          [ str "Level Progression?"
+          , str ""
+          , C.hCenter $ drawOption "YES" YesOption (selectedOption ps)
+          , C.hCenter $ drawOption "NO" NoOption (selectedOption ps)
+          , str ""
+          , C.hCenter $ str "Use ↑↓ or j/k"
+          , C.hCenter $ str "to Select."
+          , str ""
+          , C.hCenter $ str "Press Enter"
+          , C.hCenter $ str "to Continue."
+          ]
     ]
 
-drawNextShape :: Tetrimino -> Widget Name
-drawNextShape t =
-  withBorderStyle BS.unicodeBold
-    $ B.borderWithLabel (str "Next")
-    $ padTopBottom 1
-    $ padLeftRight 4
-    $ vLimit 4
-    $ vBox
-    $ [0, -1] <&> \y ->
-      hBox [ if V2 x y `elem` coords blk
-             then drawBlockCell NormalBlock t
-             else emptyNextShapeCellW
-           | x <- [-2 .. 1]
-           ]
-  where blk = Block t (V2 0 0) (relCells t)
+drawOption :: String -> MenuOption -> MenuOption -> Widget ()
+drawOption label opt current =
+  withAttr (if opt == current then selectedAttr else attrName "")
+    $ str $ "  " ++ label ++ "  "
 
-drawHelp :: Widget Name
-drawHelp =
-  withBorderStyle BS.unicodeBold
-    $ B.borderWithLabel (str "Help")
-    $ padTopBottom 1
-    $ vBox
-    $ map (uncurry drawKeyInfo)
-      [ ("Left"   , "h, ←")
-      , ("Right"  , "l, →")
-      , ("Down"   , "j, ↓")
-      , ("Rotate" , "k, ↑")
-      , ("Drop"   , "space")
-      , ("Restart", "r")
-      , ("Pause"  , "p")
-      , ("Quit"   , "q")
-      ]
+handleEvent :: BrickEvent () e -> EventM () PickState ()
+handleEvent (VtyEvent (V.EvKey V.KEsc        _)) = halt
+handleEvent (VtyEvent (V.EvKey (V.KChar 'q') _)) = halt
+handleEvent (VtyEvent (V.EvKey (V.KChar 'Q') _)) = halt
+handleEvent (VtyEvent (V.EvKey (V.KChar d) [])) =
+  whenPickingLevel $ when (d `elem` ['0' .. '9']) $ do
+    modify $ \s -> s { currentLevel = Just $ read [d], pickingLevel = False }
+handleEvent (VtyEvent (V.EvKey V.KEnter [])) = do
+  s <- get
+  when (not $ pickingLevel s) $ do
+    case currentLevel s of
+      Just l -> do
+        put $ PickState (Just l) (selectedOption s == YesOption) True YesOption
+        halt
+      Nothing -> pure ()
+handleEvent (VtyEvent (V.EvKey V.KUp [])) =
+  whenNotPickingLevel $ modify $ \s -> s { selectedOption = YesOption }
+handleEvent (VtyEvent (V.EvKey V.KDown [])) =
+  whenNotPickingLevel $ modify $ \s -> s { selectedOption = NoOption }
+handleEvent (VtyEvent (V.EvKey (V.KChar 'j') [])) =
+  whenNotPickingLevel $ modify $ \s -> s { selectedOption = YesOption }
+handleEvent (VtyEvent (V.EvKey (V.KChar 'k') [])) =
+  whenNotPickingLevel $ modify $ \s -> s { selectedOption = NoOption }
+handleEvent _ = pure ()
 
-drawKeyInfo :: String -> String -> Widget Name
-drawKeyInfo action keys =
-  padRight Max (padLeft (Pad 1) $ str action)
-    <+> padLeft Max (padRight (Pad 1) $ str keys)
+whenPickingLevel :: EventM () PickState () -> EventM () PickState ()
+whenPickingLevel action = do
+  picking <- gets pickingLevel
+  when picking action
 
-drawGameOver :: Game -> Widget Name
-drawGameOver g =
-  if isGameOver g
-  then padLeftRight 4 $ withAttr gameOverAttr $ str "GAME OVER"
-  else emptyWidget
+whenNotPickingLevel :: EventM () PickState () -> EventM () PickState ()
+whenNotPickingLevel action = do
+  picking <- gets pickingLevel
+  when (not picking) action
 
-theMap :: AttrMap
-theMap = attrMap
-  V.defAttr
-  [ (iAttr          , tToColor I `on` tToColor I)
-  , (oAttr          , tToColor O `on` tToColor O)
-  , (tAttr          , tToColor T `on` tToColor T)
-  , (sAttr          , tToColor S `on` tToColor S)
-  , (zAttr          , tToColor Z `on` tToColor Z)
-  , (jAttr          , tToColor J `on` tToColor J)
-  , (lAttr          , tToColor L `on` tToColor L)
-  , (ihAttr         , fg $ tToColor I)
-  , (ohAttr         , fg $ tToColor O)
-  , (thAttr         , fg $ tToColor T)
-  , (shAttr         , fg $ tToColor S)
-  , (zhAttr         , fg $ tToColor Z)
-  , (jhAttr         , fg $ tToColor J)
-  , (lhAttr         , fg $ tToColor L)
-  , (gameOverAttr   , fg V.red `V.withStyle` V.bold)
-  , (progressionAttr, fg V.green `V.withStyle` V.bold)
-  , (fixedAttr      , fg V.blue `V.withStyle` V.bold)
-  ]
+initialState :: PickState
+initialState = PickState Nothing True True YesOption
 
-tToColor :: Tetrimino -> V.Color
-tToColor I = V.cyan
-tToColor O = V.yellow
-tToColor T = V.magenta
-tToColor S = V.green
-tToColor Z = V.red
-tToColor J = V.blue
-tToColor L = V.white
-
-iAttr, oAttr, tAttr, sAttr, zAttr, jAttr, lAttr :: AttrName
-iAttr = attrName "I"
-oAttr = attrName "O"
-tAttr = attrName "T"
-sAttr = attrName "S"
-zAttr = attrName "Z"
-jAttr = attrName "J"
-lAttr = attrName "L"
-
-ihAttr, ohAttr, thAttr, shAttr, zhAttr, jhAttr, lhAttr :: AttrName
-ihAttr = attrName "Ih"
-ohAttr = attrName "Oh"
-thAttr = attrName "Th"
-shAttr = attrName "Sh"
-zhAttr = attrName "Zh"
-jhAttr = attrName "Jh"
-lhAttr = attrName "Lh"
-
-emptyAttr :: AttrName
-emptyAttr = attrName "empty"
-
-gameOverAttr :: AttrName
-gameOverAttr = attrName "gameOver"
-
-progressionAttr, fixedAttr :: AttrName
-progressionAttr = attrName "progression"
-fixedAttr = attrName "fixed"
+pickLevel :: IO LevelConfig
+pickLevel = do
+  result <- defaultMain app initialState
+  case currentLevel result of
+    Nothing -> exitSuccess
+    Just l -> return $ LevelConfig l (showProgression result)

--- a/src/UI/Game.hs
+++ b/src/UI/Game.hs
@@ -63,7 +63,7 @@ app = App
 
 playGame :: Int -> Maybe String -> Bool -> IO Game -- ^ Starting level -- ^ Preview cell (Nothing == no preview)
 playGame lvl mp prog = do
-  chan <- newBChan 10
+  chan <- newBChan 10   -- share the current level with the thread so it can adjust speed
   tv <- newTVarIO lvl
   void . forkIO $ forever $ do
     writeBChan chan Tick

--- a/src/UI/Game.hs
+++ b/src/UI/Game.hs
@@ -221,10 +221,10 @@ drawStats g =
 drawProgression :: Bool -> Widget Name
 drawProgression True =
     padLeftRight 1 $ str "Level Mode: " <+>
-    withAttr progressionAttr (str "ON")
+    withAttr progressionAttr (padLeft Max $ str "ON")
 drawProgression False =
     padLeftRight 1 $ str "Level Mode: " <+>
-    withAttr fixedAttr (str "OFF")
+    withAttr fixedAttr (padLeft Max $ str "Fixed")
 
 drawStat :: String -> Int -> Widget Name
 drawStat s n = padLeftRight 1 $ str s <+> padLeft Max (str $ show n)

--- a/src/UI/Game.hs
+++ b/src/UI/Game.hs
@@ -61,7 +61,10 @@ app = App
   , appAttrMap      = const theMap
   }
 
-playGame :: Int -> Maybe String -> Bool -> IO Game -- ^ Starting level -- ^ Preview cell (Nothing == no preview)
+playGame :: Int          -- ^ Starting level
+          -> Maybe String  -- ^ Preview cell (Nothing == no preview)
+          -> Bool         -- ^ Enable level progression
+          -> IO Game
 playGame lvl mp prog = do
   chan <- newBChan 10   -- share the current level with the thread so it can adjust speed
   tv <- newTVarIO lvl

--- a/src/UI/PickLevel.hs
+++ b/src/UI/PickLevel.hs
@@ -1,5 +1,6 @@
 module UI.PickLevel
   ( pickLevel
+  , LevelConfig(..)
   ) where
 
 import System.Exit (exitSuccess)
@@ -11,17 +12,39 @@ import qualified Brick.Widgets.Border.Style as BS
 import qualified Brick.Widgets.Center as C
 import qualified Graphics.Vty as V
 
-app :: App (Maybe Int) e ()
+data LevelConfig = LevelConfig
+  { levelNumber :: Int
+  , progression :: Bool
+  } deriving (Show, Eq)
+
+data MenuOption = YesOption | NoOption deriving (Eq)
+
+data PickState = PickState
+  { currentLevel :: Maybe Int
+  , showProgression :: Bool
+  , pickingLevel :: Bool
+  , selectedOption :: MenuOption
+  }
+
+app :: App PickState e ()
 app = App
-  { appDraw         = const [ui]
+  { appDraw         = drawUI
   , appHandleEvent  = handleEvent
   , appStartEvent   = pure ()
-  , appAttrMap      = const $ attrMap V.defAttr []
+  , appAttrMap      = const $ attrMap V.defAttr
+      [ (selectedAttr, V.black `on` V.white)
+      ]
   , appChooseCursor = neverShowCursor
   }
 
-ui :: Widget ()
-ui =
+selectedAttr :: AttrName
+selectedAttr = attrName "selected"
+
+drawUI :: PickState -> [Widget ()]
+drawUI ps = [ui ps]
+
+ui :: PickState -> Widget ()
+ui ps =
   padLeft (Pad 19)
     $ padRight (Pad 21)
     $ C.center
@@ -30,17 +53,62 @@ ui =
     $ withBorderStyle BS.unicodeBold
     $ B.borderWithLabel (str "Tetris")
     $ C.center
-    $ str " Choose Level (0-9)"
+    $ vBox
+    [ if pickingLevel ps
+        then str "Choose Level (0-9)"
+        else vBox
+          [ str "Level Progression?"
+          , str ""
+          , drawOption "YES" YesOption (selectedOption ps)
+          , drawOption "NO" NoOption (selectedOption ps)
+          , str ""
+          , str "Use ↑↓ to select"
+          , str "Press Enter to continue"
+          ]
+    ]
 
-handleEvent :: BrickEvent () e -> EventM () (Maybe Int) ()
+drawOption :: String -> MenuOption -> MenuOption -> Widget ()
+drawOption label opt current =
+  withAttr (if opt == current then selectedAttr else attrName "")
+    $ str $ "  " ++ label ++ "  "
+
+handleEvent :: BrickEvent () e -> EventM () PickState ()
 handleEvent (VtyEvent (V.EvKey V.KEsc        _)) = halt
 handleEvent (VtyEvent (V.EvKey (V.KChar 'q') _)) = halt
 handleEvent (VtyEvent (V.EvKey (V.KChar 'Q') _)) = halt
 handleEvent (VtyEvent (V.EvKey (V.KChar d) [])) =
-  when (d `elem` ['0' .. '9']) $ do
-    put $ Just $ read [d]
-    halt
+  whenPickingLevel $ when (d `elem` ['0' .. '9']) $ do
+    modify $ \s -> s { currentLevel = Just $ read [d], pickingLevel = False }
+handleEvent (VtyEvent (V.EvKey V.KEnter [])) = do
+  s <- get
+  when (not $ pickingLevel s) $ do
+    case currentLevel s of
+      Just l -> do
+        put $ PickState (Just l) (selectedOption s == YesOption) True YesOption
+        halt
+      Nothing -> pure ()
+handleEvent (VtyEvent (V.EvKey V.KUp [])) =
+  whenNotPickingLevel $ modify $ \s -> s { selectedOption = YesOption }
+handleEvent (VtyEvent (V.EvKey V.KDown [])) =
+  whenNotPickingLevel $ modify $ \s -> s { selectedOption = NoOption }
 handleEvent _ = pure ()
 
-pickLevel :: IO Int
-pickLevel = defaultMain app Nothing >>= maybe exitSuccess return
+whenPickingLevel :: EventM () PickState () -> EventM () PickState ()
+whenPickingLevel action = do
+  picking <- gets pickingLevel
+  when picking action
+
+whenNotPickingLevel :: EventM () PickState () -> EventM () PickState ()
+whenNotPickingLevel action = do
+  picking <- gets pickingLevel
+  when (not picking) action
+
+initialState :: PickState
+initialState = PickState Nothing True True YesOption
+
+pickLevel :: IO LevelConfig
+pickLevel = do
+  result <- defaultMain app initialState
+  case currentLevel result of
+    Nothing -> exitSuccess
+    Just l -> return $ LevelConfig l (showProgression result)

--- a/src/UI/PickLevel.hs
+++ b/src/UI/PickLevel.hs
@@ -59,11 +59,14 @@ ui ps =
         else vBox
           [ str "Level Progression?"
           , str ""
-          , drawOption "YES" YesOption (selectedOption ps)
-          , drawOption "NO" NoOption (selectedOption ps)
+          , C.hCenter $ drawOption "YES" YesOption (selectedOption ps)
+          , C.hCenter $ drawOption "NO" NoOption (selectedOption ps)
           , str ""
-          , str "Use ↑↓ to select"
-          , str "Press Enter to continue"
+          , C.hCenter $ str "Use ↑↓ or j/k"
+          , C.hCenter $ str "to Select."
+          , str ""
+          , C.hCenter $ str "Press Enter"
+          , C.hCenter $ str "to Continue."
           ]
     ]
 
@@ -90,6 +93,10 @@ handleEvent (VtyEvent (V.EvKey V.KEnter [])) = do
 handleEvent (VtyEvent (V.EvKey V.KUp [])) =
   whenNotPickingLevel $ modify $ \s -> s { selectedOption = YesOption }
 handleEvent (VtyEvent (V.EvKey V.KDown [])) =
+  whenNotPickingLevel $ modify $ \s -> s { selectedOption = NoOption }
+handleEvent (VtyEvent (V.EvKey (V.KChar 'j') [])) =
+  whenNotPickingLevel $ modify $ \s -> s { selectedOption = YesOption }
+handleEvent (VtyEvent (V.EvKey (V.KChar 'k') [])) =
   whenNotPickingLevel $ modify $ \s -> s { selectedOption = NoOption }
 handleEvent _ = pure ()
 

--- a/tetris.cabal
+++ b/tetris.cabal
@@ -1,5 +1,5 @@
 name:                tetris
-version:             0.1.5
+version:             0.1.6
 homepage:            https://github.com/samtay/tetris#readme
 license:             BSD3
 license-file:        LICENSE


### PR DESCRIPTION
First; I'd just like to say, **_thank you_** for building this. I've spent over 200 hours in this game, so I was surprised when my brew updated added auto leveling! Now, while it is cool, I just wanted that to be modular, since I see both game modes as different styles to enjoy the same game.

This PR makes Tetris's level progression system configurable, allowing players to choose between traditional auto-leveling gameplay or a fixed difficulty level.

Previously, the game would always increase in difficulty as players cleared lines. This change gives players more control over their gameplay experience - they can either:
- Use classic progression (**ON**): Speed increases as they clear lines
- Stay at fixed level (**OFF**): Maintain their chosen difficulty throughout

### Changes:
- Add progression flag to control whether level increases automatically
- Extend level selection to include progression mode toggle
- Add visual indicator in game UI showing current progression mode (ON/OFF)
- Preserve progression setting through game restarts
- Default to fixed level when using CLI level selection

### Technical Implementation:
- Added `progression` boolean to Game state
- Extended `LevelConfig` to include progression setting
- Modified UI to display and manage progression status
- Updated game initialization flow to respect progression setting
- Preserved backwards compatibility with CLI arguments

(This is my first time learning/using Haskell, so kindly excuse any rookie mistakes I might have made!)

Testing:
- ✅ Verify progression ON behaves like original auto-leveling
- ✅ Verify progression OFF maintains constant level
- ✅ Test progression toggle in level selection
- ✅  Confirm setting persists through game restarts
- ✅  Validate CLI level selection defaults correctly